### PR TITLE
Fix syntax. Perl 5.42 / ExtUtils::ParseXS 3.57

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1193,7 +1193,7 @@ by the underlying mechanism. An example service therefore is "ldap".
 
 
 Authen_SASL_XS
-server_new(pkg, parent, service, host = NULL, iplocalport=NULL, ipremoteport=NULL ...)
+server_new(pkg, parent, service, host = NULL, iplocalport=NULL, ipremoteport=NULL, ...)
 	char *pkg
 	SV *parent
 	char *service
@@ -1263,7 +1263,7 @@ See SYNOPSIS for an example.
 =cut
 
 Authen_SASL_XS
-client_new(pkg, parent, service, host, iplocalport = NULL, ipremoteport = NULL...)
+client_new(pkg, parent, service, host, iplocalport = NULL, ipremoteport = NULL, ...)
     char *pkg
     SV *parent
     char *service


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Authen-SASL-XS.
We thought you might be interested in it too.

    Description: Fix syntax. Perl 5.42 / ExtUtils::ParseXS 3.57
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-08-23
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libauthen-sasl-xs-perl/raw/master/debian/patches/perl-5.42.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
